### PR TITLE
Update ReSpec-rendered specification versions for Overlay

### DIFF
--- a/overlay/latest.html
+++ b/overlay/latest.html
@@ -23,8 +23,6 @@ dfn{cursor:pointer}
 .dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
 </style>
 <title>Overlay Specification v1.0.0</title>
-<script type="text/javascript" async="" src="https://www.google-analytics.com/analytics.js"></script>
-<script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js?id=G-JR4K3ZJLPH&amp;l=dataLayer&amp;cx=c"></script>
 <style id="respec-mainstyle">
 @keyframes pop{
 0%{transform:scale(1,1)}
@@ -70,6 +68,8 @@ dd{margin-left:0}
 }
 </style>
 
+<script type="text/javascript" async="" src="https://www.google-analytics.com/analytics.js"></script>
+<script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js?id=G-JR4K3ZJLPH&amp;l=dataLayer&amp;cx=c"></script>
 <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-831873-42"></script>
 
 <script>
@@ -80,8 +80,7 @@ dd{margin-left:0}
 </script>
 
 <meta name="color-scheme" content="light">
-<meta name="description" content="The Overlay Specification is an extension or companion to the [OpenAPI] specification.
-An Overlay describes a set of changes to be applied or “overlaid” onto an existing OpenAPI description.">
+<meta name="description" content="TBD">
 <link rel="canonical" href="https://spec.openapis.org/overlay/v1.0.0.html">
 <style>
 var{position:relative;cursor:pointer}
@@ -156,14 +155,14 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       ]
     }
   ],
-  "publishISODate": "2024-09-10T00:00:00.000Z",
-  "generatedSubtitle": "10 September 2024"
+  "publishISODate": "2024-09-12T00:00:00.000Z",
+  "generatedSubtitle": "12 September 2024"
 }</script>
-<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/base.css"></head><body class="h-entry"><div class="head">
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/base.css"></head><body class="h-entry toc-inline"><div class="head">
     <p class="logos"><a class="logo" href="https://openapis.org/"><img crossorigin="" alt="OpenAPI Initiative" height="48" src="https://raw.githubusercontent.com/OAI/OpenAPI-Style-Guide/master/graphics/bitmap/OpenAPI_Logo_Pantone.png">
   </a></p>
     <h1 id="title" class="title">Overlay Specification v1.0.0 </h1> <h2 id="subtitle" class="subtitle">Version 1.0.0</h2>
-    <p id="w3c-state"> <time class="dt-published" datetime="2024-09-10">10 September 2024</time></p>
+    <p id="w3c-state"> <time class="dt-published" datetime="2024-09-12">12 September 2024</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
@@ -217,30 +216,20 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   </div><style>
 #respec-ui { visibility: hidden; }#title { color: #578000; } #subtitle { color: #578000; }.dt-published { color: #578000; } .dt-published::before { content: "Published "; }h1,h2,h3,h4,h5,h6 { color: #578000; font-weight: normal; font-style: normal; }a[href] { color: #45512c; }body:not(.toc-inline) #toc h2 { color: #45512c; }table { display: block; width: 100%; overflow: auto; }table th { font-weight: 600; }table th, table td { padding: 6px 13px; border: 1px solid #dfe2e5; }table tr { background-color: #fff; border-top: 1px solid #c6cbd1; }table tr:nth-child(2n) { background-color: #f6f8fa; }pre { background-color: #f6f8fa !important; }code { color: #c83500 } th code { color: inherit }a.bibref { text-decoration: underline;}/**  * GitHub Gist Theme  * Author : Louis Barranqueiro - https://github.com/LouisBarranqueiro  */  .hljs {   display: block;   background: white;   padding: 0.5em;   color: #333333;   overflow-x: auto; }  .hljs-comment, .hljs-meta {   color: #727070; }  .hljs-string, .hljs-variable, .hljs-template-variable, .hljs-strong, .hljs-emphasis, .hljs-quote {   color: #c74700; }  .hljs-number {   color: #005e5e; }  .hljs-keyword, .hljs-selector-tag, .hljs-type {   color: #a71d5d; }  .hljs-literal, .hljs-symbol, .hljs-bullet, .hljs-attribute {   color: #007aa2; }  .hljs-section, .hljs-name {   color: #4b7c46; }  .hljs-tag {   color: #333333; }  .hljs-title, .hljs-attr, .hljs-selector-id, .hljs-selector-class, .hljs-selector-attr, .hljs-selector-pseudo {   color: #795da3; }  .hljs-addition {   color: #55a532;   background-color: #eaffea; }  .hljs-deletion {   color: #bd2c00;   background-color: #ffecec; }  .hljs-link {   text-decoration: underline; } 
 </style><section class="notoc introductory" id="abstract"><h2>What is the Overlay Specification?</h2>
-<p>The Overlay Specification is an extension or companion to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-openapi" title="OpenAPI Specification">OpenAPI</a></cite>] specification.
-An Overlay describes a set of changes to be applied or “overlaid” onto an existing OpenAPI description.</p>
-<p>The main purpose of the Overlay Specification is to provide a way to repeatably apply transformations to one or many OpenAPI descriptions.
-Use cases include updating descriptions, adding metadata to be consumed by another tool, or removing certain elements from an API description before sharing it with partners.
-An Overlay may be specific to a single OpenAPI description, or be designed to apply the same transform to any OpenAPI description.</p>
-</section><section class="override introductory notoc" id="sotd" data-max-toc="0"><h2>Status of This Document</h2>The source-of-truth for this specification is the HTML file referenced above as <em>This version</em>.</section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay-specification"><bdi class="secno">1. </bdi>Overlay Specification</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">1.1 </bdi>Version 1.0.0</a></li></ol></li><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">2. </bdi>Introduction</a></li><li class="tocline"><a class="tocxref" href="#definitions"><bdi class="secno">3. </bdi><span>Definitions</span></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay"><bdi class="secno">3.1 </bdi><span>Overlay</span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#specification"><bdi class="secno">4. </bdi>Specification</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#versions"><bdi class="secno">4.1 </bdi>Versions</a></li><li class="tocline"><a class="tocxref" href="#format"><bdi class="secno">4.2 </bdi>Format</a></li><li class="tocline"><a class="tocxref" href="#document-structure"><bdi class="secno">4.3 </bdi>Document Structure</a></li><li class="tocline"><a class="tocxref" href="#relative-references-in-urls"><bdi class="secno">4.4 </bdi>Relative References in URLs</a></li><li class="tocline"><a class="tocxref" href="#schema"><bdi class="secno">4.5 </bdi>Schema</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay-object"><bdi class="secno">4.5.1 </bdi>Overlay Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields"><bdi class="secno">4.5.1.1 </bdi>Fixed Fields</a></li></ol></li><li class="tocline"><a class="tocxref" href="#info-object"><bdi class="secno">4.5.2 </bdi>Info Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields-0"><bdi class="secno">4.5.2.1 </bdi>Fixed Fields</a></li></ol></li><li class="tocline"><a class="tocxref" href="#action-object"><bdi class="secno">4.5.3 </bdi>Action Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields-1"><bdi class="secno">4.5.3.1 </bdi>Fixed Fields</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#examples"><bdi class="secno">4.6 </bdi>Examples</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#structured-overlays-example"><bdi class="secno">4.6.1 </bdi>Structured Overlays Example</a></li><li class="tocline"><a class="tocxref" href="#targeted-overlays"><bdi class="secno">4.6.2 </bdi>Targeted Overlays</a></li><li class="tocline"><a class="tocxref" href="#wildcard-overlays-examples"><bdi class="secno">4.6.3 </bdi>Wildcard Overlays Examples</a></li><li class="tocline"><a class="tocxref" href="#array-modification-examples"><bdi class="secno">4.6.4 </bdi>Array Modification Examples</a></li><li class="tocline"><a class="tocxref" href="#traits-examples"><bdi class="secno">4.6.5 </bdi>Traits Examples</a></li></ol></li><li class="tocline"><a class="tocxref" href="#specification-extensions"><bdi class="secno">4.7 </bdi>Specification Extensions</a></li></ol></li><li class="tocline"><a class="tocxref" href="#appendix-a-revision-history"><bdi class="secno">A. </bdi>Appendix A: Revision History</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">B. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">B.1 </bdi>Normative references</a></li></ol></li></ol></nav>
+<p>TBD</p>
+</section><section class="override introductory notoc" id="sotd" data-max-toc="0"><h2>Status of This Document</h2>The source-of-truth for this specification is the HTML file referenced above as <em>This version</em>.</section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay-specification"><bdi class="secno">1. </bdi>Overlay Specification</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">1.1 </bdi>Version 1.0.0</a></li></ol></li><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">2. </bdi>Introduction</a></li><li class="tocline"><a class="tocxref" href="#definitions"><bdi class="secno">3. </bdi><span>Definitions</span></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay-document"><bdi class="secno">3.1 </bdi><span>Overlay Document</span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#specification"><bdi class="secno">4. </bdi>Specification</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#versions"><bdi class="secno">4.1 </bdi>Versions</a></li><li class="tocline"><a class="tocxref" href="#format"><bdi class="secno">4.2 </bdi>Format</a></li><li class="tocline"><a class="tocxref" href="#document-structure"><bdi class="secno">4.3 </bdi>Document Structure</a></li><li class="tocline"><a class="tocxref" href="#data-types"><bdi class="secno">4.4 </bdi>Data Types</a></li><li class="tocline"><a class="tocxref" href="#relative-references-in-urls"><bdi class="secno">4.5 </bdi>Relative References in URLs</a></li><li class="tocline"><a class="tocxref" href="#schema"><bdi class="secno">4.6 </bdi>Schema</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay-object"><bdi class="secno">4.6.1 </bdi>Overlay Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields"><bdi class="secno">4.6.1.1 </bdi>Fixed Fields</a></li></ol></li><li class="tocline"><a class="tocxref" href="#info-object"><bdi class="secno">4.6.2 </bdi>Info Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields-0"><bdi class="secno">4.6.2.1 </bdi>Fixed Fields</a></li></ol></li><li class="tocline"><a class="tocxref" href="#action-object"><bdi class="secno">4.6.3 </bdi>Action Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields-1"><bdi class="secno">4.6.3.1 </bdi>Fixed Fields</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#examples"><bdi class="secno">4.7 </bdi>Examples</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#structured-overlays-example"><bdi class="secno">4.7.1 </bdi>Structured Overlays Example</a></li><li class="tocline"><a class="tocxref" href="#targeted-overlays"><bdi class="secno">4.7.2 </bdi>Targeted Overlays</a></li><li class="tocline"><a class="tocxref" href="#wildcard-overlays-examples"><bdi class="secno">4.7.3 </bdi>Wildcard Overlays Examples</a></li><li class="tocline"><a class="tocxref" href="#array-modification-examples"><bdi class="secno">4.7.4 </bdi>Array Modification Examples</a></li><li class="tocline"><a class="tocxref" href="#traits-examples"><bdi class="secno">4.7.5 </bdi>Traits Examples</a></li></ol></li><li class="tocline"><a class="tocxref" href="#specification-extensions"><bdi class="secno">4.8 </bdi>Specification Extensions</a></li></ol></li><li class="tocline"><a class="tocxref" href="#appendix-a-revision-history"><bdi class="secno">A. </bdi>Appendix A: Revision History</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">B. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">B.1 </bdi>Normative references</a></li></ol></li></ol></nav>
 <section id="overlay-specification"><div class="header-wrapper"><h2 id="x1-overlay-specification"><bdi class="secno">1. </bdi>Overlay Specification</h2><a class="self-link" href="#overlay-specification" aria-label="Permalink for Section 1."></a></div>
 <section class="override" id="conformance"><div class="header-wrapper"><h3 id="x1-1-version-1-0-0"><bdi class="secno">1.1 </bdi>Version 1.0.0</h3><a class="self-link" href="#conformance" aria-label="Permalink for Section 1.1"></a></div>
 <p>The key words “<em class="rfc2119">MUST</em>”, “<em class="rfc2119">MUST NOT</em>”, “<em class="rfc2119">REQUIRED</em>”, “<em class="rfc2119">SHALL</em>”, “<em class="rfc2119">SHALL NOT</em>”, “<em class="rfc2119">SHOULD</em>”, “<em class="rfc2119">SHOULD NOT</em>”, “<em class="rfc2119">RECOMMENDED</em>”, “<em class="rfc2119">NOT RECOMMENDED</em>”, “<em class="rfc2119">MAY</em>”, and “<em class="rfc2119">OPTIONAL</em>” in this document are to be interpreted as described in <a href="https://tools.ietf.org/html/bcp14">BCP 14</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>] when, and only when, they appear in all capitals, as shown here.</p>
 <p>This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License, Version 2.0</a>.</p>
 </section></section><section id="introduction"><div class="header-wrapper"><h2 id="x2-introduction"><bdi class="secno">2. </bdi>Introduction</h2><a class="self-link" href="#introduction" aria-label="Permalink for Section 2."></a></div>
-<p>The Overlay Specification is an extension or companion to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-openapi" title="OpenAPI Specification">OpenAPI</a></cite>] specification.
-An Overlay describes a set of changes to be applied or “overlaid” onto an existing OpenAPI description.</p>
-<p>The main purpose of the Overlay Specification is to provide a way to repeatably apply transformations to one or many OpenAPI descriptions.
-Use cases include updating descriptions, adding metadata to be consumed by another tool, or removing certain elements from an API description before sharing it with partners.
-An Overlay may be specific to a single OpenAPI description, or be designed to apply the same transform to any OpenAPI description.</p>
+<p>TBD</p>
 </section><section id="definitions"><div class="header-wrapper"><h2 id="x3-definitions"><bdi class="secno">3. </bdi><dfn id="dfn-definitions" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Definitions</dfn></h2><a class="self-link" href="#definitions" aria-label="Permalink for Section 3."></a></div>
-<section id="overlay"><div class="header-wrapper"><h3 id="x3-1-overlay"><bdi class="secno">3.1 </bdi><dfn id="dfn-overlay" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Overlay</dfn></h3><a class="self-link" href="#overlay" aria-label="Permalink for Section 3.1"></a></div>
-<p>An Overlay is a JSON or YAML structure containing an ordered list of <a href="#overlay-actions">Action Objects</a> that are to be applied to the target document. Each <a href="#action-object">Action Object</a> has a <code>target</code> property and a modifier type (<code>update</code> or <code>remove</code>). The <code>target</code> property is a <cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9535" title="JSONPath: Query Expressions for JSON">JSONPath</a></cite> query expression that identifies the elements of the target document to be updated and the modifier determines the change.</p>
+<section id="overlay-document"><div class="header-wrapper"><h3 id="x3-1-overlay-document"><bdi class="secno">3.1 </bdi><dfn id="dfn-overlay-document" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Overlay Document</dfn></h3><a class="self-link" href="#overlay-document" aria-label="Permalink for Section 3.1"></a></div>
+<p>An overlay document contains an ordered list of <a href="#overlay-actions">Action Objects</a> that are to be applied to the target document. Each <a href="#action-object">Action Object</a> has a <code>target</code> property and a modifier type (<code>update</code> or <code>remove</code>). The <code>target</code> property is a <cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9535" title="JSONPath: Query Expressions for JSON">JSONPath</a></cite> query expression that identifies the elements of the target document to be updated and the modifier determines the change.</p>
 </section></section><section id="specification"><div class="header-wrapper"><h2 id="x4-specification"><bdi class="secno">4. </bdi>Specification</h2><a class="self-link" href="#specification" aria-label="Permalink for Section 4."></a></div>
 <section id="versions"><div class="header-wrapper"><h3 id="x4-1-versions"><bdi class="secno">4.1 </bdi>Versions</h3><a class="self-link" href="#versions" aria-label="Permalink for Section 4.1"></a></div>
-<p>The Overlay Specification is versioned using a <code>major</code>.<code>minor</code>.<code>patch</code> versioning scheme. The <code>major</code>.<code>minor</code> portion of the version string (for example 1.0) <em class="rfc2119">SHALL</em> designate the Overlay feature set. <code>.patch</code> versions address errors in, or provide clarifications to, this document, not the feature set. The patch version <em class="rfc2119">SHOULD NOT</em> be considered by tooling, making no distinction between 1.0.0 and 1.0.1 for example.</p>
-<p><strong>Note:</strong> Version 1.0.0 of the Overlay Specification is being released after spending some time in draft, and after being adopted by tool providers.
-Check with your tool provider for the details of what is supported in each tool.</p>
+<p>TBD</p>
 </section><section id="format"><div class="header-wrapper"><h3 id="x4-2-format"><bdi class="secno">4.2 </bdi>Format</h3><a class="self-link" href="#format" aria-label="Permalink for Section 4.2"></a></div>
 <p>An Overlay document that conforms to the Overlay Specification is itself a JSON object, which may be represented either in <cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7159" title="The JavaScript Object Notation (JSON) Data Interchange Format">JSON</a></cite> or <cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) Version 1.2">YAML</a></cite> format.</p>
 <p>All field names in the specification are <strong>case sensitive</strong>.
@@ -252,14 +241,16 @@ This includes all fields that are used as keys in a map, except where explicitly
 </ul>
 </section><section id="document-structure"><div class="header-wrapper"><h3 id="x4-3-document-structure"><bdi class="secno">4.3 </bdi>Document Structure</h3><a class="self-link" href="#document-structure" aria-label="Permalink for Section 4.3"></a></div>
 <p>It is <em class="rfc2119">RECOMMENDED</em> that the root Overlay document be named: <code>overlay.json</code> or <code>overlay.yaml</code>.</p>
-</section><section id="relative-references-in-urls"><div class="header-wrapper"><h3 id="x4-4-relative-references-in-urls"><bdi class="secno">4.4 </bdi>Relative References in URLs</h3><a class="self-link" href="#relative-references-in-urls" aria-label="Permalink for Section 4.4"></a></div>
+</section><section id="data-types"><div class="header-wrapper"><h3 id="x4-4-data-types"><bdi class="secno">4.4 </bdi>Data Types</h3><a class="self-link" href="#data-types" aria-label="Permalink for Section 4.4"></a></div>
+<p>TBD</p>
+</section><section id="relative-references-in-urls"><div class="header-wrapper"><h3 id="x4-5-relative-references-in-urls"><bdi class="secno">4.5 </bdi>Relative References in URLs</h3><a class="self-link" href="#relative-references-in-urls" aria-label="Permalink for Section 4.5"></a></div>
 <p>Unless specified otherwise, all properties that are URLs <em class="rfc2119">MAY</em> be relative references as defined by [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-4.2">Section 4.2</a>.
 Unless specified otherwise, relative references are resolved using the URL of the referring document.</p>
-</section><section id="schema"><div class="header-wrapper"><h3 id="x4-5-schema"><bdi class="secno">4.5 </bdi>Schema</h3><a class="self-link" href="#schema" aria-label="Permalink for Section 4.5"></a></div>
+</section><section id="schema"><div class="header-wrapper"><h3 id="x4-6-schema"><bdi class="secno">4.6 </bdi>Schema</h3><a class="self-link" href="#schema" aria-label="Permalink for Section 4.6"></a></div>
 <p>In the following description, if a field is not explicitly <strong><em class="rfc2119">REQUIRED</em></strong> or described with a <em class="rfc2119">MUST</em> or <em class="rfc2119">SHALL</em>, it can be considered <em class="rfc2119">OPTIONAL</em>.</p>
-<section id="overlay-object"><div class="header-wrapper"><h4 id="x4-5-1-overlay-object"><bdi class="secno">4.5.1 </bdi>Overlay Object</h4><a class="self-link" href="#overlay-object" aria-label="Permalink for Section 4.5.1"></a></div>
-<p>This is the root object of the <a href="#overlay">Overlay</a>.</p>
-<section id="fixed-fields"><div class="header-wrapper"><h5 id="x4-5-1-1-fixed-fields"><bdi class="secno">4.5.1.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields" aria-label="Permalink for Section 4.5.1.1"></a></div>
+<section id="overlay-object"><div class="header-wrapper"><h4 id="x4-6-1-overlay-object"><bdi class="secno">4.6.1 </bdi>Overlay Object</h4><a class="self-link" href="#overlay-object" aria-label="Permalink for Section 4.6.1"></a></div>
+<p>This is the root object of the <a href="#overlay-document">Overlay document</a>.</p>
+<section id="fixed-fields"><div class="header-wrapper"><h5 id="x4-6-1-1-fixed-fields"><bdi class="secno">4.6.1.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields" aria-label="Permalink for Section 4.6.1.1"></a></div>
 <table>
 <thead>
 <tr>
@@ -294,10 +285,10 @@ Unless specified otherwise, relative references are resolved using the URL of th
 <p>This object <em class="rfc2119">MAY</em> be extended with <a href="#specification-extensions">Specification Extensions</a>.</p>
 <p>The list of actions <em class="rfc2119">MUST</em> be applied in sequential order to ensure a consistent outcome. Actions are applied to the result of the previous updates. This enables objects to be deleted in one update and then re-created in a subsequent update, for example.</p>
 <p>The <code>extends</code> property can be used to indicate that the Overlay was designed to update a specific [<cite><a class="bibref" data-link-type="biblio" href="#bib-openapi" title="OpenAPI Specification">OpenAPI</a></cite>] document. Where no <code>extends</code> is provided it is the responsibility of tooling to apply the Overlay documents to the appropriate OpenAPI document(s).</p>
-</section></section><section id="info-object"><div class="header-wrapper"><h4 id="x4-5-2-info-object"><bdi class="secno">4.5.2 </bdi>Info Object</h4><a class="self-link" href="#info-object" aria-label="Permalink for Section 4.5.2"></a></div>
+</section></section><section id="info-object"><div class="header-wrapper"><h4 id="x4-6-2-info-object"><bdi class="secno">4.6.2 </bdi>Info Object</h4><a class="self-link" href="#info-object" aria-label="Permalink for Section 4.6.2"></a></div>
 <p>The object provides metadata about the Overlay.
 The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
-<section id="fixed-fields-0"><div class="header-wrapper"><h5 id="x4-5-2-1-fixed-fields"><bdi class="secno">4.5.2.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields-0" aria-label="Permalink for Section 4.5.2.1"></a></div>
+<section id="fixed-fields-0"><div class="header-wrapper"><h5 id="x4-6-2-1-fixed-fields"><bdi class="secno">4.6.2.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields-0" aria-label="Permalink for Section 4.6.2.1"></a></div>
 <table>
 <thead>
 <tr>
@@ -320,9 +311,9 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
 </tbody>
 </table>
 <p>This object <em class="rfc2119">MAY</em> be extended with <a href="#specification-extensions">Specification Extensions</a>.</p>
-</section></section><section id="action-object"><div class="header-wrapper"><h4 id="x4-5-3-action-object"><bdi class="secno">4.5.3 </bdi>Action Object</h4><a class="self-link" href="#action-object" aria-label="Permalink for Section 4.5.3"></a></div>
+</section></section><section id="action-object"><div class="header-wrapper"><h4 id="x4-6-3-action-object"><bdi class="secno">4.6.3 </bdi>Action Object</h4><a class="self-link" href="#action-object" aria-label="Permalink for Section 4.6.3"></a></div>
 <p>This object represents one or more changes to be applied to the target document at the location defined by the target JSONPath expression.</p>
-<section id="fixed-fields-1"><div class="header-wrapper"><h5 id="x4-5-3-1-fixed-fields"><bdi class="secno">4.5.3.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields-1" aria-label="Permalink for Section 4.5.3.1"></a></div>
+<section id="fixed-fields-1"><div class="header-wrapper"><h5 id="x4-6-3-1-fixed-fields"><bdi class="secno">4.6.3.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields-1" aria-label="Permalink for Section 4.6.3.1"></a></div>
 <table>
 <thead>
 <tr>
@@ -357,8 +348,8 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
 <p>The result of the <code>target</code> JSONPath query expression must be zero or more objects or arrays (not primitive types or <code>null</code> values). If you wish to update a primitive value such as a string, the <code>target</code> expression should select the <em>containing</em> object in the target document.</p>
 <p>The properties of the update object <em class="rfc2119">MUST</em> be compatible with the target object referenced by the JSONPath key. When the Overlay document is applied, the properties in the merge object replace properties in the target object with the same name and new properties are appended to the target object.</p>
 <p>This object <em class="rfc2119">MAY</em> be extended with <a href="#specification-extensions">Specification Extensions</a>.</p>
-</section></section></section><section id="examples"><div class="header-wrapper"><h3 id="x4-6-examples"><bdi class="secno">4.6 </bdi>Examples</h3><a class="self-link" href="#examples" aria-label="Permalink for Section 4.6"></a></div>
-<section id="structured-overlays-example"><div class="header-wrapper"><h4 id="x4-6-1-structured-overlays-example"><bdi class="secno">4.6.1 </bdi>Structured Overlays Example</h4><a class="self-link" href="#structured-overlays-example" aria-label="Permalink for Section 4.6.1"></a></div>
+</section></section></section><section id="examples"><div class="header-wrapper"><h3 id="x4-7-examples"><bdi class="secno">4.7 </bdi>Examples</h3><a class="self-link" href="#examples" aria-label="Permalink for Section 4.7"></a></div>
+<section id="structured-overlays-example"><div class="header-wrapper"><h4 id="x4-7-1-structured-overlays-example"><bdi class="secno">4.7.1 </bdi>Structured Overlays Example</h4><a class="self-link" href="#structured-overlays-example" aria-label="Permalink for Section 4.7.1"></a></div>
 <p>When updating properties throughout the target document it may be more efficient to create a single <code>Action Object</code> that mirrors the structure of the target document. e.g.</p>
 <pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">overlay:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.0</span>
 <span class="hljs-attr">info:</span>
@@ -382,7 +373,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
       <span class="hljs-attr">components:</span>
       <span class="hljs-attr">tags:</span>
 </code></pre>
-</section><section id="targeted-overlays"><div class="header-wrapper"><h4 id="x4-6-2-targeted-overlays"><bdi class="secno">4.6.2 </bdi>Targeted Overlays</h4><a class="self-link" href="#targeted-overlays" aria-label="Permalink for Section 4.6.2"></a></div>
+</section><section id="targeted-overlays"><div class="header-wrapper"><h4 id="x4-7-2-targeted-overlays"><bdi class="secno">4.7.2 </bdi>Targeted Overlays</h4><a class="self-link" href="#targeted-overlays" aria-label="Permalink for Section 4.7.2"></a></div>
 <p>Alternatively, where only a small number of updates need to be applied to a large document, each <a href="#action-object">Action Object</a> <em class="rfc2119">MAY</em> be more targeted.</p>
 <pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">overlay:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.0</span>
 <span class="hljs-attr">info:</span>
@@ -401,7 +392,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
         <span class="hljs-attr">description:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">an</span> <span class="hljs-string">updated</span> <span class="hljs-string">description</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">child</span> <span class="hljs-string">object</span>
         <span class="hljs-attr">x-safe:</span> <span class="hljs-literal">false</span>
 </code></pre>
-</section><section id="wildcard-overlays-examples"><div class="header-wrapper"><h4 id="x4-6-3-wildcard-overlays-examples"><bdi class="secno">4.6.3 </bdi>Wildcard Overlays Examples</h4><a class="self-link" href="#wildcard-overlays-examples" aria-label="Permalink for Section 4.6.3"></a></div>
+</section><section id="wildcard-overlays-examples"><div class="header-wrapper"><h4 id="x4-7-3-wildcard-overlays-examples"><bdi class="secno">4.7.3 </bdi>Wildcard Overlays Examples</h4><a class="self-link" href="#wildcard-overlays-examples" aria-label="Permalink for Section 4.7.3"></a></div>
 <p>One significant advantage of using the JSONPath syntax is that it allows referencing multiple nodes in the target document. This would allow a single update object to be applied to multiple target objects using wildcards and other multi-value selectors.</p>
 <pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">overlay:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.0</span>
 <span class="hljs-attr">info:</span>
@@ -416,7 +407,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
       <span class="hljs-attr">schema:</span>
         <span class="hljs-string">$ref:</span> <span class="hljs-string">'/components/schemas/filterSchema'</span>
 </code></pre>
-</section><section id="array-modification-examples"><div class="header-wrapper"><h4 id="x4-6-4-array-modification-examples"><bdi class="secno">4.6.4 </bdi>Array Modification Examples</h4><a class="self-link" href="#array-modification-examples" aria-label="Permalink for Section 4.6.4"></a></div>
+</section><section id="array-modification-examples"><div class="header-wrapper"><h4 id="x4-7-4-array-modification-examples"><bdi class="secno">4.7.4 </bdi>Array Modification Examples</h4><a class="self-link" href="#array-modification-examples" aria-label="Permalink for Section 4.7.4"></a></div>
 <p>Array elements <em class="rfc2119">MAY</em> be deleted using the <code>remove</code> property. Use of array indexes to remove array items should be avoided where possible as indexes will change when items are removed.</p>
 <pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">overlay:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.0</span>
 <span class="hljs-attr">info:</span>
@@ -436,7 +427,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
   <span class="hljs-bullet">-</span> <span class="hljs-attr">target:</span> <span class="hljs-string">$.paths.*.get.parameters[?@.name</span> <span class="hljs-string">==</span> <span class="hljs-string">'dummy'</span><span class="hljs-string">]</span>
     <span class="hljs-attr">remove:</span> <span class="hljs-literal">true</span>
 </code></pre>
-</section><section id="traits-examples"><div class="header-wrapper"><h4 id="x4-6-5-traits-examples"><bdi class="secno">4.6.5 </bdi>Traits Examples</h4><a class="self-link" href="#traits-examples" aria-label="Permalink for Section 4.6.5"></a></div>
+</section><section id="traits-examples"><div class="header-wrapper"><h4 id="x4-7-5-traits-examples"><bdi class="secno">4.7.5 </bdi>Traits Examples</h4><a class="self-link" href="#traits-examples" aria-label="Permalink for Section 4.7.5"></a></div>
 <p>By annotating a target document (such as an [<cite><a class="bibref" data-link-type="biblio" href="#bib-openapi" title="OpenAPI Specification">OpenAPI</a></cite>] document) using specification extensions such as <code>x-oai-traits</code>, the author of the target document <em class="rfc2119">MAY</em> identify where overlay updates should be applied.</p>
 <pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">openapi:</span> <span class="hljs-number">3.1</span><span class="hljs-number">.0</span>
 <span class="hljs-attr">info:</span>
@@ -467,7 +458,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
           <span class="hljs-comment"># ...</span>
 </code></pre>
 <p>This approach allows inversion of control as to where the Overlay updates apply to the target document itself.</p>
-</section></section><section id="specification-extensions"><div class="header-wrapper"><h3 id="x4-7-specification-extensions"><bdi class="secno">4.7 </bdi>Specification Extensions</h3><a class="self-link" href="#specification-extensions" aria-label="Permalink for Section 4.7"></a></div>
+</section></section><section id="specification-extensions"><div class="header-wrapper"><h3 id="x4-8-specification-extensions"><bdi class="secno">4.8 </bdi>Specification Extensions</h3><a class="self-link" href="#specification-extensions" aria-label="Permalink for Section 4.8"></a></div>
 <p>While the Overlay Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.</p>
 <p>The extension properties are implemented as patterned fields that are always prefixed by <code>"x-"</code>.</p>
 <table>
@@ -536,10 +527,10 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
       <ul>
       <li>Not referenced in this document.</li>
     </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-overlay" aria-label="Links in this document to definition: Overlay">
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-overlay-document" aria-label="Links in this document to definition: Overlay Document">
       <span class="caret"></span>
       <div>
-        <a class="self-link" href="#dfn-overlay" aria-label="Permalink for definition: Overlay. Activate to close this dialog.">Permalink</a>
+        <a class="self-link" href="#dfn-overlay-document" aria-label="Permalink for definition: Overlay Document. Activate to close this dialog.">Permalink</a>
          
       </div>
       <p><b>Referenced in:</b></p>

--- a/overlay/v1.0.0.html
+++ b/overlay/v1.0.0.html
@@ -23,8 +23,6 @@ dfn{cursor:pointer}
 .dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
 </style>
 <title>Overlay Specification v1.0.0</title>
-<script type="text/javascript" async="" src="https://www.google-analytics.com/analytics.js"></script>
-<script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js?id=G-JR4K3ZJLPH&amp;l=dataLayer&amp;cx=c"></script>
 <style id="respec-mainstyle">
 @keyframes pop{
 0%{transform:scale(1,1)}
@@ -70,6 +68,8 @@ dd{margin-left:0}
 }
 </style>
 
+<script type="text/javascript" async="" src="https://www.google-analytics.com/analytics.js"></script>
+<script type="text/javascript" async="" src="https://www.googletagmanager.com/gtag/js?id=G-JR4K3ZJLPH&amp;l=dataLayer&amp;cx=c"></script>
 <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-831873-42"></script>
 
 <script>
@@ -80,8 +80,7 @@ dd{margin-left:0}
 </script>
 
 <meta name="color-scheme" content="light">
-<meta name="description" content="The Overlay Specification is an extension or companion to the [OpenAPI] specification.
-An Overlay describes a set of changes to be applied or “overlaid” onto an existing OpenAPI description.">
+<meta name="description" content="TBD">
 <link rel="canonical" href="https://spec.openapis.org/overlay/v1.0.0.html">
 <style>
 var{position:relative;cursor:pointer}
@@ -156,14 +155,14 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       ]
     }
   ],
-  "publishISODate": "2024-09-10T00:00:00.000Z",
-  "generatedSubtitle": "10 September 2024"
+  "publishISODate": "2024-09-12T00:00:00.000Z",
+  "generatedSubtitle": "12 September 2024"
 }</script>
-<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/base.css"></head><body class="h-entry"><div class="head">
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/base.css"></head><body class="h-entry toc-inline"><div class="head">
     <p class="logos"><a class="logo" href="https://openapis.org/"><img crossorigin="" alt="OpenAPI Initiative" height="48" src="https://raw.githubusercontent.com/OAI/OpenAPI-Style-Guide/master/graphics/bitmap/OpenAPI_Logo_Pantone.png">
   </a></p>
     <h1 id="title" class="title">Overlay Specification v1.0.0 </h1> <h2 id="subtitle" class="subtitle">Version 1.0.0</h2>
-    <p id="w3c-state"> <time class="dt-published" datetime="2024-09-10">10 September 2024</time></p>
+    <p id="w3c-state"> <time class="dt-published" datetime="2024-09-12">12 September 2024</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
@@ -217,30 +216,20 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
   </div><style>
 #respec-ui { visibility: hidden; }#title { color: #578000; } #subtitle { color: #578000; }.dt-published { color: #578000; } .dt-published::before { content: "Published "; }h1,h2,h3,h4,h5,h6 { color: #578000; font-weight: normal; font-style: normal; }a[href] { color: #45512c; }body:not(.toc-inline) #toc h2 { color: #45512c; }table { display: block; width: 100%; overflow: auto; }table th { font-weight: 600; }table th, table td { padding: 6px 13px; border: 1px solid #dfe2e5; }table tr { background-color: #fff; border-top: 1px solid #c6cbd1; }table tr:nth-child(2n) { background-color: #f6f8fa; }pre { background-color: #f6f8fa !important; }code { color: #c83500 } th code { color: inherit }a.bibref { text-decoration: underline;}/**  * GitHub Gist Theme  * Author : Louis Barranqueiro - https://github.com/LouisBarranqueiro  */  .hljs {   display: block;   background: white;   padding: 0.5em;   color: #333333;   overflow-x: auto; }  .hljs-comment, .hljs-meta {   color: #727070; }  .hljs-string, .hljs-variable, .hljs-template-variable, .hljs-strong, .hljs-emphasis, .hljs-quote {   color: #c74700; }  .hljs-number {   color: #005e5e; }  .hljs-keyword, .hljs-selector-tag, .hljs-type {   color: #a71d5d; }  .hljs-literal, .hljs-symbol, .hljs-bullet, .hljs-attribute {   color: #007aa2; }  .hljs-section, .hljs-name {   color: #4b7c46; }  .hljs-tag {   color: #333333; }  .hljs-title, .hljs-attr, .hljs-selector-id, .hljs-selector-class, .hljs-selector-attr, .hljs-selector-pseudo {   color: #795da3; }  .hljs-addition {   color: #55a532;   background-color: #eaffea; }  .hljs-deletion {   color: #bd2c00;   background-color: #ffecec; }  .hljs-link {   text-decoration: underline; } 
 </style><section class="notoc introductory" id="abstract"><h2>What is the Overlay Specification?</h2>
-<p>The Overlay Specification is an extension or companion to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-openapi" title="OpenAPI Specification">OpenAPI</a></cite>] specification.
-An Overlay describes a set of changes to be applied or “overlaid” onto an existing OpenAPI description.</p>
-<p>The main purpose of the Overlay Specification is to provide a way to repeatably apply transformations to one or many OpenAPI descriptions.
-Use cases include updating descriptions, adding metadata to be consumed by another tool, or removing certain elements from an API description before sharing it with partners.
-An Overlay may be specific to a single OpenAPI description, or be designed to apply the same transform to any OpenAPI description.</p>
-</section><section class="override introductory notoc" id="sotd" data-max-toc="0"><h2>Status of This Document</h2>The source-of-truth for this specification is the HTML file referenced above as <em>This version</em>.</section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay-specification"><bdi class="secno">1. </bdi>Overlay Specification</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">1.1 </bdi>Version 1.0.0</a></li></ol></li><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">2. </bdi>Introduction</a></li><li class="tocline"><a class="tocxref" href="#definitions"><bdi class="secno">3. </bdi><span>Definitions</span></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay"><bdi class="secno">3.1 </bdi><span>Overlay</span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#specification"><bdi class="secno">4. </bdi>Specification</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#versions"><bdi class="secno">4.1 </bdi>Versions</a></li><li class="tocline"><a class="tocxref" href="#format"><bdi class="secno">4.2 </bdi>Format</a></li><li class="tocline"><a class="tocxref" href="#document-structure"><bdi class="secno">4.3 </bdi>Document Structure</a></li><li class="tocline"><a class="tocxref" href="#relative-references-in-urls"><bdi class="secno">4.4 </bdi>Relative References in URLs</a></li><li class="tocline"><a class="tocxref" href="#schema"><bdi class="secno">4.5 </bdi>Schema</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay-object"><bdi class="secno">4.5.1 </bdi>Overlay Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields"><bdi class="secno">4.5.1.1 </bdi>Fixed Fields</a></li></ol></li><li class="tocline"><a class="tocxref" href="#info-object"><bdi class="secno">4.5.2 </bdi>Info Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields-0"><bdi class="secno">4.5.2.1 </bdi>Fixed Fields</a></li></ol></li><li class="tocline"><a class="tocxref" href="#action-object"><bdi class="secno">4.5.3 </bdi>Action Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields-1"><bdi class="secno">4.5.3.1 </bdi>Fixed Fields</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#examples"><bdi class="secno">4.6 </bdi>Examples</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#structured-overlays-example"><bdi class="secno">4.6.1 </bdi>Structured Overlays Example</a></li><li class="tocline"><a class="tocxref" href="#targeted-overlays"><bdi class="secno">4.6.2 </bdi>Targeted Overlays</a></li><li class="tocline"><a class="tocxref" href="#wildcard-overlays-examples"><bdi class="secno">4.6.3 </bdi>Wildcard Overlays Examples</a></li><li class="tocline"><a class="tocxref" href="#array-modification-examples"><bdi class="secno">4.6.4 </bdi>Array Modification Examples</a></li><li class="tocline"><a class="tocxref" href="#traits-examples"><bdi class="secno">4.6.5 </bdi>Traits Examples</a></li></ol></li><li class="tocline"><a class="tocxref" href="#specification-extensions"><bdi class="secno">4.7 </bdi>Specification Extensions</a></li></ol></li><li class="tocline"><a class="tocxref" href="#appendix-a-revision-history"><bdi class="secno">A. </bdi>Appendix A: Revision History</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">B. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">B.1 </bdi>Normative references</a></li></ol></li></ol></nav>
+<p>TBD</p>
+</section><section class="override introductory notoc" id="sotd" data-max-toc="0"><h2>Status of This Document</h2>The source-of-truth for this specification is the HTML file referenced above as <em>This version</em>.</section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay-specification"><bdi class="secno">1. </bdi>Overlay Specification</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">1.1 </bdi>Version 1.0.0</a></li></ol></li><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">2. </bdi>Introduction</a></li><li class="tocline"><a class="tocxref" href="#definitions"><bdi class="secno">3. </bdi><span>Definitions</span></a><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay-document"><bdi class="secno">3.1 </bdi><span>Overlay Document</span></a></li></ol></li><li class="tocline"><a class="tocxref" href="#specification"><bdi class="secno">4. </bdi>Specification</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#versions"><bdi class="secno">4.1 </bdi>Versions</a></li><li class="tocline"><a class="tocxref" href="#format"><bdi class="secno">4.2 </bdi>Format</a></li><li class="tocline"><a class="tocxref" href="#document-structure"><bdi class="secno">4.3 </bdi>Document Structure</a></li><li class="tocline"><a class="tocxref" href="#data-types"><bdi class="secno">4.4 </bdi>Data Types</a></li><li class="tocline"><a class="tocxref" href="#relative-references-in-urls"><bdi class="secno">4.5 </bdi>Relative References in URLs</a></li><li class="tocline"><a class="tocxref" href="#schema"><bdi class="secno">4.6 </bdi>Schema</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#overlay-object"><bdi class="secno">4.6.1 </bdi>Overlay Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields"><bdi class="secno">4.6.1.1 </bdi>Fixed Fields</a></li></ol></li><li class="tocline"><a class="tocxref" href="#info-object"><bdi class="secno">4.6.2 </bdi>Info Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields-0"><bdi class="secno">4.6.2.1 </bdi>Fixed Fields</a></li></ol></li><li class="tocline"><a class="tocxref" href="#action-object"><bdi class="secno">4.6.3 </bdi>Action Object</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fixed-fields-1"><bdi class="secno">4.6.3.1 </bdi>Fixed Fields</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#examples"><bdi class="secno">4.7 </bdi>Examples</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#structured-overlays-example"><bdi class="secno">4.7.1 </bdi>Structured Overlays Example</a></li><li class="tocline"><a class="tocxref" href="#targeted-overlays"><bdi class="secno">4.7.2 </bdi>Targeted Overlays</a></li><li class="tocline"><a class="tocxref" href="#wildcard-overlays-examples"><bdi class="secno">4.7.3 </bdi>Wildcard Overlays Examples</a></li><li class="tocline"><a class="tocxref" href="#array-modification-examples"><bdi class="secno">4.7.4 </bdi>Array Modification Examples</a></li><li class="tocline"><a class="tocxref" href="#traits-examples"><bdi class="secno">4.7.5 </bdi>Traits Examples</a></li></ol></li><li class="tocline"><a class="tocxref" href="#specification-extensions"><bdi class="secno">4.8 </bdi>Specification Extensions</a></li></ol></li><li class="tocline"><a class="tocxref" href="#appendix-a-revision-history"><bdi class="secno">A. </bdi>Appendix A: Revision History</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">B. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">B.1 </bdi>Normative references</a></li></ol></li></ol></nav>
 <section id="overlay-specification"><div class="header-wrapper"><h2 id="x1-overlay-specification"><bdi class="secno">1. </bdi>Overlay Specification</h2><a class="self-link" href="#overlay-specification" aria-label="Permalink for Section 1."></a></div>
 <section class="override" id="conformance"><div class="header-wrapper"><h3 id="x1-1-version-1-0-0"><bdi class="secno">1.1 </bdi>Version 1.0.0</h3><a class="self-link" href="#conformance" aria-label="Permalink for Section 1.1"></a></div>
 <p>The key words “<em class="rfc2119">MUST</em>”, “<em class="rfc2119">MUST NOT</em>”, “<em class="rfc2119">REQUIRED</em>”, “<em class="rfc2119">SHALL</em>”, “<em class="rfc2119">SHALL NOT</em>”, “<em class="rfc2119">SHOULD</em>”, “<em class="rfc2119">SHOULD NOT</em>”, “<em class="rfc2119">RECOMMENDED</em>”, “<em class="rfc2119">NOT RECOMMENDED</em>”, “<em class="rfc2119">MAY</em>”, and “<em class="rfc2119">OPTIONAL</em>” in this document are to be interpreted as described in <a href="https://tools.ietf.org/html/bcp14">BCP 14</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>] when, and only when, they appear in all capitals, as shown here.</p>
 <p>This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License, Version 2.0</a>.</p>
 </section></section><section id="introduction"><div class="header-wrapper"><h2 id="x2-introduction"><bdi class="secno">2. </bdi>Introduction</h2><a class="self-link" href="#introduction" aria-label="Permalink for Section 2."></a></div>
-<p>The Overlay Specification is an extension or companion to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-openapi" title="OpenAPI Specification">OpenAPI</a></cite>] specification.
-An Overlay describes a set of changes to be applied or “overlaid” onto an existing OpenAPI description.</p>
-<p>The main purpose of the Overlay Specification is to provide a way to repeatably apply transformations to one or many OpenAPI descriptions.
-Use cases include updating descriptions, adding metadata to be consumed by another tool, or removing certain elements from an API description before sharing it with partners.
-An Overlay may be specific to a single OpenAPI description, or be designed to apply the same transform to any OpenAPI description.</p>
+<p>TBD</p>
 </section><section id="definitions"><div class="header-wrapper"><h2 id="x3-definitions"><bdi class="secno">3. </bdi><dfn id="dfn-definitions" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Definitions</dfn></h2><a class="self-link" href="#definitions" aria-label="Permalink for Section 3."></a></div>
-<section id="overlay"><div class="header-wrapper"><h3 id="x3-1-overlay"><bdi class="secno">3.1 </bdi><dfn id="dfn-overlay" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Overlay</dfn></h3><a class="self-link" href="#overlay" aria-label="Permalink for Section 3.1"></a></div>
-<p>An Overlay is a JSON or YAML structure containing an ordered list of <a href="#overlay-actions">Action Objects</a> that are to be applied to the target document. Each <a href="#action-object">Action Object</a> has a <code>target</code> property and a modifier type (<code>update</code> or <code>remove</code>). The <code>target</code> property is a <cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9535" title="JSONPath: Query Expressions for JSON">JSONPath</a></cite> query expression that identifies the elements of the target document to be updated and the modifier determines the change.</p>
+<section id="overlay-document"><div class="header-wrapper"><h3 id="x3-1-overlay-document"><bdi class="secno">3.1 </bdi><dfn id="dfn-overlay-document" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Overlay Document</dfn></h3><a class="self-link" href="#overlay-document" aria-label="Permalink for Section 3.1"></a></div>
+<p>An overlay document contains an ordered list of <a href="#overlay-actions">Action Objects</a> that are to be applied to the target document. Each <a href="#action-object">Action Object</a> has a <code>target</code> property and a modifier type (<code>update</code> or <code>remove</code>). The <code>target</code> property is a <cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9535" title="JSONPath: Query Expressions for JSON">JSONPath</a></cite> query expression that identifies the elements of the target document to be updated and the modifier determines the change.</p>
 </section></section><section id="specification"><div class="header-wrapper"><h2 id="x4-specification"><bdi class="secno">4. </bdi>Specification</h2><a class="self-link" href="#specification" aria-label="Permalink for Section 4."></a></div>
 <section id="versions"><div class="header-wrapper"><h3 id="x4-1-versions"><bdi class="secno">4.1 </bdi>Versions</h3><a class="self-link" href="#versions" aria-label="Permalink for Section 4.1"></a></div>
-<p>The Overlay Specification is versioned using a <code>major</code>.<code>minor</code>.<code>patch</code> versioning scheme. The <code>major</code>.<code>minor</code> portion of the version string (for example 1.0) <em class="rfc2119">SHALL</em> designate the Overlay feature set. <code>.patch</code> versions address errors in, or provide clarifications to, this document, not the feature set. The patch version <em class="rfc2119">SHOULD NOT</em> be considered by tooling, making no distinction between 1.0.0 and 1.0.1 for example.</p>
-<p><strong>Note:</strong> Version 1.0.0 of the Overlay Specification is being released after spending some time in draft, and after being adopted by tool providers.
-Check with your tool provider for the details of what is supported in each tool.</p>
+<p>TBD</p>
 </section><section id="format"><div class="header-wrapper"><h3 id="x4-2-format"><bdi class="secno">4.2 </bdi>Format</h3><a class="self-link" href="#format" aria-label="Permalink for Section 4.2"></a></div>
 <p>An Overlay document that conforms to the Overlay Specification is itself a JSON object, which may be represented either in <cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7159" title="The JavaScript Object Notation (JSON) Data Interchange Format">JSON</a></cite> or <cite><a class="bibref" data-link-type="biblio" href="#bib-yaml" title="YAML Ain’t Markup Language (YAML™) Version 1.2">YAML</a></cite> format.</p>
 <p>All field names in the specification are <strong>case sensitive</strong>.
@@ -252,14 +241,16 @@ This includes all fields that are used as keys in a map, except where explicitly
 </ul>
 </section><section id="document-structure"><div class="header-wrapper"><h3 id="x4-3-document-structure"><bdi class="secno">4.3 </bdi>Document Structure</h3><a class="self-link" href="#document-structure" aria-label="Permalink for Section 4.3"></a></div>
 <p>It is <em class="rfc2119">RECOMMENDED</em> that the root Overlay document be named: <code>overlay.json</code> or <code>overlay.yaml</code>.</p>
-</section><section id="relative-references-in-urls"><div class="header-wrapper"><h3 id="x4-4-relative-references-in-urls"><bdi class="secno">4.4 </bdi>Relative References in URLs</h3><a class="self-link" href="#relative-references-in-urls" aria-label="Permalink for Section 4.4"></a></div>
+</section><section id="data-types"><div class="header-wrapper"><h3 id="x4-4-data-types"><bdi class="secno">4.4 </bdi>Data Types</h3><a class="self-link" href="#data-types" aria-label="Permalink for Section 4.4"></a></div>
+<p>TBD</p>
+</section><section id="relative-references-in-urls"><div class="header-wrapper"><h3 id="x4-5-relative-references-in-urls"><bdi class="secno">4.5 </bdi>Relative References in URLs</h3><a class="self-link" href="#relative-references-in-urls" aria-label="Permalink for Section 4.5"></a></div>
 <p>Unless specified otherwise, all properties that are URLs <em class="rfc2119">MAY</em> be relative references as defined by [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-4.2">Section 4.2</a>.
 Unless specified otherwise, relative references are resolved using the URL of the referring document.</p>
-</section><section id="schema"><div class="header-wrapper"><h3 id="x4-5-schema"><bdi class="secno">4.5 </bdi>Schema</h3><a class="self-link" href="#schema" aria-label="Permalink for Section 4.5"></a></div>
+</section><section id="schema"><div class="header-wrapper"><h3 id="x4-6-schema"><bdi class="secno">4.6 </bdi>Schema</h3><a class="self-link" href="#schema" aria-label="Permalink for Section 4.6"></a></div>
 <p>In the following description, if a field is not explicitly <strong><em class="rfc2119">REQUIRED</em></strong> or described with a <em class="rfc2119">MUST</em> or <em class="rfc2119">SHALL</em>, it can be considered <em class="rfc2119">OPTIONAL</em>.</p>
-<section id="overlay-object"><div class="header-wrapper"><h4 id="x4-5-1-overlay-object"><bdi class="secno">4.5.1 </bdi>Overlay Object</h4><a class="self-link" href="#overlay-object" aria-label="Permalink for Section 4.5.1"></a></div>
-<p>This is the root object of the <a href="#overlay">Overlay</a>.</p>
-<section id="fixed-fields"><div class="header-wrapper"><h5 id="x4-5-1-1-fixed-fields"><bdi class="secno">4.5.1.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields" aria-label="Permalink for Section 4.5.1.1"></a></div>
+<section id="overlay-object"><div class="header-wrapper"><h4 id="x4-6-1-overlay-object"><bdi class="secno">4.6.1 </bdi>Overlay Object</h4><a class="self-link" href="#overlay-object" aria-label="Permalink for Section 4.6.1"></a></div>
+<p>This is the root object of the <a href="#overlay-document">Overlay document</a>.</p>
+<section id="fixed-fields"><div class="header-wrapper"><h5 id="x4-6-1-1-fixed-fields"><bdi class="secno">4.6.1.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields" aria-label="Permalink for Section 4.6.1.1"></a></div>
 <table>
 <thead>
 <tr>
@@ -294,10 +285,10 @@ Unless specified otherwise, relative references are resolved using the URL of th
 <p>This object <em class="rfc2119">MAY</em> be extended with <a href="#specification-extensions">Specification Extensions</a>.</p>
 <p>The list of actions <em class="rfc2119">MUST</em> be applied in sequential order to ensure a consistent outcome. Actions are applied to the result of the previous updates. This enables objects to be deleted in one update and then re-created in a subsequent update, for example.</p>
 <p>The <code>extends</code> property can be used to indicate that the Overlay was designed to update a specific [<cite><a class="bibref" data-link-type="biblio" href="#bib-openapi" title="OpenAPI Specification">OpenAPI</a></cite>] document. Where no <code>extends</code> is provided it is the responsibility of tooling to apply the Overlay documents to the appropriate OpenAPI document(s).</p>
-</section></section><section id="info-object"><div class="header-wrapper"><h4 id="x4-5-2-info-object"><bdi class="secno">4.5.2 </bdi>Info Object</h4><a class="self-link" href="#info-object" aria-label="Permalink for Section 4.5.2"></a></div>
+</section></section><section id="info-object"><div class="header-wrapper"><h4 id="x4-6-2-info-object"><bdi class="secno">4.6.2 </bdi>Info Object</h4><a class="self-link" href="#info-object" aria-label="Permalink for Section 4.6.2"></a></div>
 <p>The object provides metadata about the Overlay.
 The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
-<section id="fixed-fields-0"><div class="header-wrapper"><h5 id="x4-5-2-1-fixed-fields"><bdi class="secno">4.5.2.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields-0" aria-label="Permalink for Section 4.5.2.1"></a></div>
+<section id="fixed-fields-0"><div class="header-wrapper"><h5 id="x4-6-2-1-fixed-fields"><bdi class="secno">4.6.2.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields-0" aria-label="Permalink for Section 4.6.2.1"></a></div>
 <table>
 <thead>
 <tr>
@@ -320,9 +311,9 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
 </tbody>
 </table>
 <p>This object <em class="rfc2119">MAY</em> be extended with <a href="#specification-extensions">Specification Extensions</a>.</p>
-</section></section><section id="action-object"><div class="header-wrapper"><h4 id="x4-5-3-action-object"><bdi class="secno">4.5.3 </bdi>Action Object</h4><a class="self-link" href="#action-object" aria-label="Permalink for Section 4.5.3"></a></div>
+</section></section><section id="action-object"><div class="header-wrapper"><h4 id="x4-6-3-action-object"><bdi class="secno">4.6.3 </bdi>Action Object</h4><a class="self-link" href="#action-object" aria-label="Permalink for Section 4.6.3"></a></div>
 <p>This object represents one or more changes to be applied to the target document at the location defined by the target JSONPath expression.</p>
-<section id="fixed-fields-1"><div class="header-wrapper"><h5 id="x4-5-3-1-fixed-fields"><bdi class="secno">4.5.3.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields-1" aria-label="Permalink for Section 4.5.3.1"></a></div>
+<section id="fixed-fields-1"><div class="header-wrapper"><h5 id="x4-6-3-1-fixed-fields"><bdi class="secno">4.6.3.1 </bdi>Fixed Fields</h5><a class="self-link" href="#fixed-fields-1" aria-label="Permalink for Section 4.6.3.1"></a></div>
 <table>
 <thead>
 <tr>
@@ -357,8 +348,8 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
 <p>The result of the <code>target</code> JSONPath query expression must be zero or more objects or arrays (not primitive types or <code>null</code> values). If you wish to update a primitive value such as a string, the <code>target</code> expression should select the <em>containing</em> object in the target document.</p>
 <p>The properties of the update object <em class="rfc2119">MUST</em> be compatible with the target object referenced by the JSONPath key. When the Overlay document is applied, the properties in the merge object replace properties in the target object with the same name and new properties are appended to the target object.</p>
 <p>This object <em class="rfc2119">MAY</em> be extended with <a href="#specification-extensions">Specification Extensions</a>.</p>
-</section></section></section><section id="examples"><div class="header-wrapper"><h3 id="x4-6-examples"><bdi class="secno">4.6 </bdi>Examples</h3><a class="self-link" href="#examples" aria-label="Permalink for Section 4.6"></a></div>
-<section id="structured-overlays-example"><div class="header-wrapper"><h4 id="x4-6-1-structured-overlays-example"><bdi class="secno">4.6.1 </bdi>Structured Overlays Example</h4><a class="self-link" href="#structured-overlays-example" aria-label="Permalink for Section 4.6.1"></a></div>
+</section></section></section><section id="examples"><div class="header-wrapper"><h3 id="x4-7-examples"><bdi class="secno">4.7 </bdi>Examples</h3><a class="self-link" href="#examples" aria-label="Permalink for Section 4.7"></a></div>
+<section id="structured-overlays-example"><div class="header-wrapper"><h4 id="x4-7-1-structured-overlays-example"><bdi class="secno">4.7.1 </bdi>Structured Overlays Example</h4><a class="self-link" href="#structured-overlays-example" aria-label="Permalink for Section 4.7.1"></a></div>
 <p>When updating properties throughout the target document it may be more efficient to create a single <code>Action Object</code> that mirrors the structure of the target document. e.g.</p>
 <pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">overlay:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.0</span>
 <span class="hljs-attr">info:</span>
@@ -382,7 +373,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
       <span class="hljs-attr">components:</span>
       <span class="hljs-attr">tags:</span>
 </code></pre>
-</section><section id="targeted-overlays"><div class="header-wrapper"><h4 id="x4-6-2-targeted-overlays"><bdi class="secno">4.6.2 </bdi>Targeted Overlays</h4><a class="self-link" href="#targeted-overlays" aria-label="Permalink for Section 4.6.2"></a></div>
+</section><section id="targeted-overlays"><div class="header-wrapper"><h4 id="x4-7-2-targeted-overlays"><bdi class="secno">4.7.2 </bdi>Targeted Overlays</h4><a class="self-link" href="#targeted-overlays" aria-label="Permalink for Section 4.7.2"></a></div>
 <p>Alternatively, where only a small number of updates need to be applied to a large document, each <a href="#action-object">Action Object</a> <em class="rfc2119">MAY</em> be more targeted.</p>
 <pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">overlay:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.0</span>
 <span class="hljs-attr">info:</span>
@@ -401,7 +392,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
         <span class="hljs-attr">description:</span> <span class="hljs-string">This</span> <span class="hljs-string">is</span> <span class="hljs-string">an</span> <span class="hljs-string">updated</span> <span class="hljs-string">description</span> <span class="hljs-string">of</span> <span class="hljs-string">a</span> <span class="hljs-string">child</span> <span class="hljs-string">object</span>
         <span class="hljs-attr">x-safe:</span> <span class="hljs-literal">false</span>
 </code></pre>
-</section><section id="wildcard-overlays-examples"><div class="header-wrapper"><h4 id="x4-6-3-wildcard-overlays-examples"><bdi class="secno">4.6.3 </bdi>Wildcard Overlays Examples</h4><a class="self-link" href="#wildcard-overlays-examples" aria-label="Permalink for Section 4.6.3"></a></div>
+</section><section id="wildcard-overlays-examples"><div class="header-wrapper"><h4 id="x4-7-3-wildcard-overlays-examples"><bdi class="secno">4.7.3 </bdi>Wildcard Overlays Examples</h4><a class="self-link" href="#wildcard-overlays-examples" aria-label="Permalink for Section 4.7.3"></a></div>
 <p>One significant advantage of using the JSONPath syntax is that it allows referencing multiple nodes in the target document. This would allow a single update object to be applied to multiple target objects using wildcards and other multi-value selectors.</p>
 <pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">overlay:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.0</span>
 <span class="hljs-attr">info:</span>
@@ -416,7 +407,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
       <span class="hljs-attr">schema:</span>
         <span class="hljs-string">$ref:</span> <span class="hljs-string">'/components/schemas/filterSchema'</span>
 </code></pre>
-</section><section id="array-modification-examples"><div class="header-wrapper"><h4 id="x4-6-4-array-modification-examples"><bdi class="secno">4.6.4 </bdi>Array Modification Examples</h4><a class="self-link" href="#array-modification-examples" aria-label="Permalink for Section 4.6.4"></a></div>
+</section><section id="array-modification-examples"><div class="header-wrapper"><h4 id="x4-7-4-array-modification-examples"><bdi class="secno">4.7.4 </bdi>Array Modification Examples</h4><a class="self-link" href="#array-modification-examples" aria-label="Permalink for Section 4.7.4"></a></div>
 <p>Array elements <em class="rfc2119">MAY</em> be deleted using the <code>remove</code> property. Use of array indexes to remove array items should be avoided where possible as indexes will change when items are removed.</p>
 <pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">overlay:</span> <span class="hljs-number">1.0</span><span class="hljs-number">.0</span>
 <span class="hljs-attr">info:</span>
@@ -436,7 +427,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
   <span class="hljs-bullet">-</span> <span class="hljs-attr">target:</span> <span class="hljs-string">$.paths.*.get.parameters[?@.name</span> <span class="hljs-string">==</span> <span class="hljs-string">'dummy'</span><span class="hljs-string">]</span>
     <span class="hljs-attr">remove:</span> <span class="hljs-literal">true</span>
 </code></pre>
-</section><section id="traits-examples"><div class="header-wrapper"><h4 id="x4-6-5-traits-examples"><bdi class="secno">4.6.5 </bdi>Traits Examples</h4><a class="self-link" href="#traits-examples" aria-label="Permalink for Section 4.6.5"></a></div>
+</section><section id="traits-examples"><div class="header-wrapper"><h4 id="x4-7-5-traits-examples"><bdi class="secno">4.7.5 </bdi>Traits Examples</h4><a class="self-link" href="#traits-examples" aria-label="Permalink for Section 4.7.5"></a></div>
 <p>By annotating a target document (such as an [<cite><a class="bibref" data-link-type="biblio" href="#bib-openapi" title="OpenAPI Specification">OpenAPI</a></cite>] document) using specification extensions such as <code>x-oai-traits</code>, the author of the target document <em class="rfc2119">MAY</em> identify where overlay updates should be applied.</p>
 <pre class="nohighlight" tabindex="0"><code><span class="hljs-attr">openapi:</span> <span class="hljs-number">3.1</span><span class="hljs-number">.0</span>
 <span class="hljs-attr">info:</span>
@@ -467,7 +458,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
           <span class="hljs-comment"># ...</span>
 </code></pre>
 <p>This approach allows inversion of control as to where the Overlay updates apply to the target document itself.</p>
-</section></section><section id="specification-extensions"><div class="header-wrapper"><h3 id="x4-7-specification-extensions"><bdi class="secno">4.7 </bdi>Specification Extensions</h3><a class="self-link" href="#specification-extensions" aria-label="Permalink for Section 4.7"></a></div>
+</section></section><section id="specification-extensions"><div class="header-wrapper"><h3 id="x4-8-specification-extensions"><bdi class="secno">4.8 </bdi>Specification Extensions</h3><a class="self-link" href="#specification-extensions" aria-label="Permalink for Section 4.8"></a></div>
 <p>While the Overlay Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.</p>
 <p>The extension properties are implemented as patterned fields that are always prefixed by <code>"x-"</code>.</p>
 <table>
@@ -536,10 +527,10 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
       <ul>
       <li>Not referenced in this document.</li>
     </ul>
-    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-overlay" aria-label="Links in this document to definition: Overlay">
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-overlay-document" aria-label="Links in this document to definition: Overlay Document">
       <span class="caret"></span>
       <div>
-        <a class="self-link" href="#dfn-overlay" aria-label="Permalink for definition: Overlay. Activate to close this dialog.">Permalink</a>
+        <a class="self-link" href="#dfn-overlay-document" aria-label="Permalink for definition: Overlay Document. Activate to close this dialog.">Permalink</a>
          
       </div>
       <p><b>Referenced in:</b></p>


### PR DESCRIPTION
This pull request is automatically triggered by GitHub action `respec` in the OAI/Overlay-Specification repo.

The `versions/*.md` files have changed, so the HTML files are automatically being regenerated.