### PR TITLE
Update ReSpec-rendered specification versions for Overlay

### DIFF
--- a/overlay/latest.html
+++ b/overlay/latest.html
@@ -156,14 +156,14 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       ]
     }
   ],
-  "publishISODate": "2024-09-10T00:00:00.000Z",
-  "generatedSubtitle": "10 September 2024"
+  "publishISODate": "2024-09-13T00:00:00.000Z",
+  "generatedSubtitle": "13 September 2024"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/base.css"></head><body class="h-entry"><div class="head">
     <p class="logos"><a class="logo" href="https://openapis.org/"><img crossorigin="" alt="OpenAPI Initiative" height="48" src="https://raw.githubusercontent.com/OAI/OpenAPI-Style-Guide/master/graphics/bitmap/OpenAPI_Logo_Pantone.png">
   </a></p>
     <h1 id="title" class="title">Overlay Specification v1.0.0 </h1> <h2 id="subtitle" class="subtitle">Version 1.0.0</h2>
-    <p id="w3c-state"> <time class="dt-published" datetime="2024-09-10">10 September 2024</time></p>
+    <p id="w3c-state"> <time class="dt-published" datetime="2024-09-13">13 September 2024</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
@@ -335,7 +335,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
 <tr>
 <td><span id="action-target"></span>target</td>
 <td style="text-align:center"><code>string</code></td>
-<td><strong><em class="rfc2119">REQUIRED</em></strong> A JSONPath query expression referencing the target objects in the target document.</td>
+<td><strong><em class="rfc2119">REQUIRED</em></strong> A JSONPath expression selecting nodes in the target document.</td>
 </tr>
 <tr>
 <td><span id="action-description"></span>description</td>
@@ -345,7 +345,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
 <tr>
 <td><span id="action-update"></span>update</td>
 <td style="text-align:center">Any</td>
-<td>An object with the properties and values to be merged with the object(s) referenced by the <code>target</code>. This property has no impact if <code>remove</code> property is <code>true</code>.</td>
+<td>If the <code>target</code> selects an object node, the value of this field should be an object with the properties and values to merge with the node. If the <code>target</code> selects an array, the value of this field should be an entry to append to the array. This field has no impact if the <code>remove</code> field of this action object is <code>true</code>.</td>
 </tr>
 <tr>
 <td><span id="action-remove"></span>remove</td>
@@ -354,7 +354,9 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
 </tr>
 </tbody>
 </table>
-<p>The result of the <code>target</code> JSONPath query expression must be zero or more objects or arrays (not primitive types or <code>null</code> values). If you wish to update a primitive value such as a string, the <code>target</code> expression should select the <em>containing</em> object in the target document.</p>
+<p>The result of the <code>target</code> JSONPath expression must be zero or more objects or arrays (not primitive types or <code>null</code> values).</p>
+<p>To update a primitive property value such as a string, the <code>target</code> expression should select the <em>containing</em> object in the target document and <code>update</code> should contain an object with the property and its new primitive value.</p>
+<p>Primitive-valued items of an array cannot be replaced or removed individually, only the complete array can be replaced.</p>
 <p>The properties of the update object <em class="rfc2119">MUST</em> be compatible with the target object referenced by the JSONPath key. When the Overlay document is applied, the properties in the merge object replace properties in the target object with the same name and new properties are appended to the target object.</p>
 <p>This object <em class="rfc2119">MAY</em> be extended with <a href="#specification-extensions">Specification Extensions</a>.</p>
 </section></section></section><section id="examples"><div class="header-wrapper"><h3 id="x4-6-examples"><bdi class="secno">4.6 </bdi>Examples</h3><a class="self-link" href="#examples" aria-label="Permalink for Section 4.6"></a></div>

--- a/overlay/v1.0.0.html
+++ b/overlay/v1.0.0.html
@@ -156,14 +156,14 @@ var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
       ]
     }
   ],
-  "publishISODate": "2024-09-10T00:00:00.000Z",
-  "generatedSubtitle": "10 September 2024"
+  "publishISODate": "2024-09-13T00:00:00.000Z",
+  "generatedSubtitle": "13 September 2024"
 }</script>
 <link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/base.css"></head><body class="h-entry"><div class="head">
     <p class="logos"><a class="logo" href="https://openapis.org/"><img crossorigin="" alt="OpenAPI Initiative" height="48" src="https://raw.githubusercontent.com/OAI/OpenAPI-Style-Guide/master/graphics/bitmap/OpenAPI_Logo_Pantone.png">
   </a></p>
     <h1 id="title" class="title">Overlay Specification v1.0.0 </h1> <h2 id="subtitle" class="subtitle">Version 1.0.0</h2>
-    <p id="w3c-state"> <time class="dt-published" datetime="2024-09-10">10 September 2024</time></p>
+    <p id="w3c-state"> <time class="dt-published" datetime="2024-09-13">13 September 2024</time></p>
     <details open="">
       <summary>More details about this document</summary>
       <dl>
@@ -335,7 +335,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
 <tr>
 <td><span id="action-target"></span>target</td>
 <td style="text-align:center"><code>string</code></td>
-<td><strong><em class="rfc2119">REQUIRED</em></strong> A JSONPath query expression referencing the target objects in the target document.</td>
+<td><strong><em class="rfc2119">REQUIRED</em></strong> A JSONPath expression selecting nodes in the target document.</td>
 </tr>
 <tr>
 <td><span id="action-description"></span>description</td>
@@ -345,7 +345,7 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
 <tr>
 <td><span id="action-update"></span>update</td>
 <td style="text-align:center">Any</td>
-<td>An object with the properties and values to be merged with the object(s) referenced by the <code>target</code>. This property has no impact if <code>remove</code> property is <code>true</code>.</td>
+<td>If the <code>target</code> selects an object node, the value of this field should be an object with the properties and values to merge with the node. If the <code>target</code> selects an array, the value of this field should be an entry to append to the array. This field has no impact if the <code>remove</code> field of this action object is <code>true</code>.</td>
 </tr>
 <tr>
 <td><span id="action-remove"></span>remove</td>
@@ -354,7 +354,9 @@ The metadata <em class="rfc2119">MAY</em> be used by the clients if needed.</p>
 </tr>
 </tbody>
 </table>
-<p>The result of the <code>target</code> JSONPath query expression must be zero or more objects or arrays (not primitive types or <code>null</code> values). If you wish to update a primitive value such as a string, the <code>target</code> expression should select the <em>containing</em> object in the target document.</p>
+<p>The result of the <code>target</code> JSONPath expression must be zero or more objects or arrays (not primitive types or <code>null</code> values).</p>
+<p>To update a primitive property value such as a string, the <code>target</code> expression should select the <em>containing</em> object in the target document and <code>update</code> should contain an object with the property and its new primitive value.</p>
+<p>Primitive-valued items of an array cannot be replaced or removed individually, only the complete array can be replaced.</p>
 <p>The properties of the update object <em class="rfc2119">MUST</em> be compatible with the target object referenced by the JSONPath key. When the Overlay document is applied, the properties in the merge object replace properties in the target object with the same name and new properties are appended to the target object.</p>
 <p>This object <em class="rfc2119">MAY</em> be extended with <a href="#specification-extensions">Specification Extensions</a>.</p>
 </section></section></section><section id="examples"><div class="header-wrapper"><h3 id="x4-6-examples"><bdi class="secno">4.6 </bdi>Examples</h3><a class="self-link" href="#examples" aria-label="Permalink for Section 4.6"></a></div>


### PR DESCRIPTION
This pull request is automatically triggered by GitHub action `respec` in the OAI/Overlay-Specification repo.

The `versions/*.md` files have changed, so the HTML files are automatically being regenerated.